### PR TITLE
:bookmark: bump version 0.1.3 -> 0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
         run: exit 1
 
   pypi:
-    if: ${{ github.event_name == 'release' }}
     runs-on: ubuntu-latest
     needs: check
     environment: release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.2.0]
+
 ### Added
 
 -   Now using `django-twc-package` as as package template.
@@ -68,8 +70,9 @@ Initial release!
     -   Edit and build the icon registry in `icons.py`
 -   Initial documentation
 
-[unreleased]: https://github.com/joshuadavidthomas/wagtail-heroicons/compare/v0.1.3...HEAD
+[unreleased]: git@github.com:joshuadavidthomas/wagtail-heroicons/compare/v0.2.0...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.1
 [0.1.2]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.2
 [0.1.3]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.3
+[0.2.0]: git@github.com:joshuadavidthomas/wagtail-heroicons/releases/tag/v0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ Source = "https://github.com/westerveltco/wagtail-heroicons"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.1.3"
+current_version = "0.2.0"
 push = false
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/wagtail_heroicons/__init__.py
+++ b/src/wagtail_heroicons/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from wagtail_heroicons import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.3"
+    assert __version__ == "0.2.0"


### PR DESCRIPTION
- `9d6a7d4`: drop support for Python 3.7 (#46)
- `a5ee6d2`: refactor package to use `nox` for testing (#45)
- `03b3078`: format CHANGELOG
- `9ef1be3`: move build script out of package (#47)
- `0b48965`: use `django-twc-package` as project template (#42)
- `3fed084`: refactor build script (#49)
- `d050820`: remove accidental zip file
- `5fbacba`: rename script
- `1ef3bc2`: adjust Wagtail versions
- `7bf3c2f`: fix spacing of badges
- `220f325`: refactor icon installation by simplifying hook (#50)
- `234cbf9`: remove extra comment from changelog
- `1d8d4b3`: rename application template directory (#51)
- `359ecf3`: add test for wagtail hook icon registration (#52)
- `5776856`: add heroicons license to repo license
- `ef0c4fa`: add back correct documentation to README
- `c341c83`: adjust description