### PR TITLE
:bookmark: bump version 0.2.1 -> 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.2.2]
+
 ### Fixed
 
 -   Fixed a bug where the icons were registered incorrectly and thus not able to be rendered by Django's `render_to_string` function. Reported by @seb-b in #58.
@@ -80,10 +82,11 @@ Initial release!
     -   Edit and build the icon registry in `icons.py`
 -   Initial documentation
 
-[unreleased]: git@github.com:joshuadavidthomas/wagtail-heroicons/compare/v0.2.1...HEAD
+[unreleased]: git@github.com:joshuadavidthomas/wagtail-heroicons/compare/v0.2.2...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.0
 [0.1.1]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.1
 [0.1.2]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.2
 [0.1.3]: https://github.com/joshuadavidthomas/wagtail-heroicons/releases/tag/v0.1.3
 [0.2.0]: git@github.com:joshuadavidthomas/wagtail-heroicons/releases/tag/v0.2.0
 [0.2.1]: git@github.com:joshuadavidthomas/wagtail-heroicons/releases/tag/v0.2.1
+[0.2.2]: git@github.com:joshuadavidthomas/wagtail-heroicons/releases/tag/v0.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ Source = "https://github.com/westerveltco/wagtail-heroicons"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.2.1"
+current_version = "0.2.2"
 push = false
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/wagtail_heroicons/__init__.py
+++ b/src/wagtail_heroicons/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from wagtail_heroicons import __version__
 
 
 def test_version():
-    assert __version__ == "0.2.1"
+    assert __version__ == "0.2.2"


### PR DESCRIPTION
- `277850c`: [pre-commit.ci] pre-commit autoupdate (#57)
- `473c708`: fix icon path in wagtail hook registration (#59)